### PR TITLE
Sqlite driver not mapping rows correctly due to faulty assumptions

### DIFF
--- a/lib/src/drivers/sqlite_driver_impl.dart
+++ b/lib/src/drivers/sqlite_driver_impl.dart
@@ -116,6 +116,9 @@ class SqliteDriverImpl extends DatabaseDriver {
 
       final rows = result.map((row) {
         final nestedMap = row.toTableColumnMap();
+        if(nestedMap == null) {
+          return Map<String, dynamic>.from(row);
+        }
         final flattened = <String, dynamic>{};
         nestedMap?.forEach((_, colMap) {
           flattened.addAll(colMap);


### PR DESCRIPTION
I noticed that the sqlite driver seems to be not able to properly map all columns when querying data.

Example select:
```
_db.select().from('media')
```
Returns list of empty maps/objects.

I checked why that happens, and I ended up here: https://github.com/evandersondev/dartonic/blob/main/lib/src/drivers/sqlite_driver_impl.dart#L118

This line returns `null`. Apparently this happens when sqlite is compiled without `SQLITE_ENABLE_COLUMN_METADATA`. Since this package is using sqlite3, we have no other choice except to use `sqlite3_flutter_libs` to provide us system sqlite binary, using dynamic linking from the device itself.

This makes this driver/package unfortunately useless when using sqlite.

This PR works around it by simply wrapping the result in this case into a modifiable map. The result rows are already unmodifiable maps with column names and their values, so I am not even sure, why is this package even calling `toTableColumnMap()`